### PR TITLE
Feature/keep cart items after ordering

### DIFF
--- a/backend/src/main/java/com/ahmetaksunger/ecommerce/config/InitialDataConfig.java
+++ b/backend/src/main/java/com/ahmetaksunger/ecommerce/config/InitialDataConfig.java
@@ -29,6 +29,7 @@ public class InitialDataConfig {
 
     private final Faker faker = new Faker();
     private final CartItemRepository cartItemRepository;
+    private final CartRepository cartRepository;
 
     /**
      * Creates specified amount of {@link Customer}s.
@@ -58,7 +59,7 @@ public class InitialDataConfig {
                     .customer(customer)
                     .build();
 
-            customer.setCart(cart);
+            cartRepository.save(cart);
             customerRepository.save(customer);
 
             final Address address = Address.builder()

--- a/backend/src/main/java/com/ahmetaksunger/ecommerce/config/InitialDataConfig.java
+++ b/backend/src/main/java/com/ahmetaksunger/ecommerce/config/InitialDataConfig.java
@@ -35,7 +35,7 @@ public class InitialDataConfig {
      * Creates specified amount of {@link Customer}s.
      * Each customer has 1 {@link Address}, 1 {@link PaymentDetail} and 1 {@link Cart}
      *
-     * @param amount amount of customers
+     * @param amount number of customers
      */
     private void createCustomers(int amount) {
         for (int i = 0; i < amount; i++) {
@@ -55,12 +55,13 @@ public class InitialDataConfig {
                     .phoneNumber(phoneNumber)
                     .build();
 
+            customerRepository.save(customer);
+
             final Cart cart = Cart.builder()
                     .customer(customer)
                     .build();
 
             cartRepository.save(cart);
-            customerRepository.save(customer);
 
             final Address address = Address.builder()
                     .address(faker.address().fullAddress())
@@ -84,11 +85,11 @@ public class InitialDataConfig {
             List<CartItem> cartItems = new ArrayList<CartItem>();
             List<Product> products = productRepository.findAll();
             for (int j = 0; j < 5; j++) {
-                var product = products.get(faker.number().numberBetween(0,products.size() - 1));
+                var product = products.get(faker.number().numberBetween(0, products.size() - 1));
                 CartItem cartItem = CartItem.builder()
                         .cart(cart)
                         .product(product)
-                        .quantity(faker.number().numberBetween(1,5))
+                        .quantity(faker.number().numberBetween(1, 5))
                         .build();
                 cartItemRepository.save(cartItem);
             }
@@ -98,7 +99,7 @@ public class InitialDataConfig {
     /**
      * Creates specified amount of @{@link Category}s
      *
-     * @param amount amount of categories
+     * @param amount number of categories
      */
     private void createCategories(int amount) {
         for (int i = 0; i < amount; i++) {

--- a/backend/src/main/java/com/ahmetaksunger/ecommerce/dto/response/OrderCompletedResponse.java
+++ b/backend/src/main/java/com/ahmetaksunger/ecommerce/dto/response/OrderCompletedResponse.java
@@ -8,9 +8,10 @@ import java.math.BigDecimal;
 @Getter @Setter
 public class OrderCompletedResponse {
 
-    private long id;
+    private Long id;
     private BigDecimal total;
     private CartVM cart;
     private PaymentDetailVM paymentDetail;
+    private Long newCartId;
 
 }

--- a/backend/src/main/java/com/ahmetaksunger/ecommerce/exception/ExceptionMessages.java
+++ b/backend/src/main/java/com/ahmetaksunger/ecommerce/exception/ExceptionMessages.java
@@ -21,6 +21,7 @@ public enum ExceptionMessages {
     INSUFF_PRODUCT_QUANTITY("Insufficient product quantity"),
     INSUFF_REVENUE("Seller doesn't have enough revenue to withdraw."),
     INVALID_WITHDRAW_AMOUNT("Invalid withdraw amount"),
+    INVALID_CART("Invalid cart"),
     CART_IS_EMPTY("Cart is empty");
 
     private String message;

--- a/backend/src/main/java/com/ahmetaksunger/ecommerce/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/ahmetaksunger/ecommerce/exception/GlobalExceptionHandler.java
@@ -8,11 +8,9 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
-import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.server.MethodNotAllowedException;
@@ -28,15 +26,15 @@ public class GlobalExceptionHandler {
     private final MapperService mapperService;
 
     @ExceptionHandler({MethodArgumentNotValidException.class})
-    public ResponseEntity<FieldExceptionResponse> handle(Exception exception, HttpServletRequest request){
-        log.error(exception.getMessage(),exception);
+    public ResponseEntity<FieldExceptionResponse> handle(Exception exception, HttpServletRequest request) {
+        log.error(exception.getMessage(), exception);
 
-        HashMap<String,String> messages = new HashMap<>();
+        HashMap<String, String> messages = new HashMap<>();
 
-        if(exception instanceof MethodArgumentNotValidException){
+        if (exception instanceof MethodArgumentNotValidException) {
             MethodArgumentNotValidException ex = (MethodArgumentNotValidException) exception;
-            for (FieldError fieldError:ex.getBindingResult().getFieldErrors()) {
-                messages.put(fieldError.getField(),fieldError.getDefaultMessage());
+            for (FieldError fieldError : ex.getBindingResult().getFieldErrors()) {
+                messages.put(fieldError.getField(), fieldError.getDefaultMessage());
             }
         }
 
@@ -48,12 +46,12 @@ public class GlobalExceptionHandler {
                 .path(request.getRequestURI())
                 .build();
 
-        return new ResponseEntity<>(response,HttpStatus.BAD_REQUEST);
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler({UnauthorizedException.class})
-    public ResponseEntity<DefaultExceptionResponse> handle(UnauthorizedException exception, HttpServletRequest request){
-        log.error(exception.getMessage(),exception);
+    public ResponseEntity<DefaultExceptionResponse> handle(UnauthorizedException exception, HttpServletRequest request) {
+        log.error(exception.getMessage(), exception);
 
         return new ResponseEntity<>(DefaultExceptionResponse.builder()
                 .status(HttpStatus.UNAUTHORIZED.value())
@@ -63,10 +61,10 @@ public class GlobalExceptionHandler {
                 .path(request.getRequestURI())
                 .build(), HttpStatus.UNAUTHORIZED);
     }
-    
+
     @ExceptionHandler({NotFoundException.class})
-    public ResponseEntity<DefaultExceptionResponse> handle(NotFoundException exception, HttpServletRequest request){
-        log.error(exception.getMessage(),exception);
+    public ResponseEntity<DefaultExceptionResponse> handle(NotFoundException exception, HttpServletRequest request) {
+        log.error(exception.getMessage(), exception);
 
         return new ResponseEntity<>(DefaultExceptionResponse.builder()
                 .status(HttpStatus.NOT_FOUND.value())
@@ -77,9 +75,14 @@ public class GlobalExceptionHandler {
                 .build(), HttpStatus.NOT_FOUND);
     }
 
-    @ExceptionHandler({InvalidRequestParamException.class,InsufficientRevenueException.class,InvalidWithdrawAmountException.class, CartIsEmptyException.class})
-    public ResponseEntity<DefaultExceptionResponse> handle(RuntimeException exception, HttpServletRequest request){
-        log.error(exception.getMessage(),exception);
+    @ExceptionHandler({
+            InvalidRequestParamException.class
+            , InsufficientRevenueException.class
+            , InvalidWithdrawAmountException.class
+            , CartIsEmptyException.class
+            , InvalidCartException.class})
+    public ResponseEntity<DefaultExceptionResponse> handle(RuntimeException exception, HttpServletRequest request) {
+        log.error(exception.getMessage(), exception);
 
         return new ResponseEntity<>(DefaultExceptionResponse.builder()
                 .status(HttpStatus.BAD_REQUEST.value())
@@ -87,12 +90,12 @@ public class GlobalExceptionHandler {
                 .message(exception.getMessage())
                 .timeStamp(System.currentTimeMillis())
                 .path(request.getRequestURI())
-                .build(),HttpStatus.BAD_REQUEST);
+                .build(), HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler({UserAlreadyHasCartException.class})
-    public ResponseEntity<DefaultExceptionResponse> handle(UserAlreadyHasCartException exception, HttpServletRequest request){
-        log.error(exception.getMessage(),exception);
+    public ResponseEntity<DefaultExceptionResponse> handle(UserAlreadyHasCartException exception, HttpServletRequest request) {
+        log.error(exception.getMessage(), exception);
 
         return new ResponseEntity<>(DefaultExceptionResponse.builder()
                 .status(HttpStatus.CONFLICT.value())
@@ -100,16 +103,16 @@ public class GlobalExceptionHandler {
                 .message(exception.getMessage())
                 .timeStamp(System.currentTimeMillis())
                 .path(request.getRequestURI())
-                .build(),HttpStatus.CONFLICT);
+                .build(), HttpStatus.CONFLICT);
     }
 
     @ExceptionHandler({InsufficientProductQuantityException.class})
-    public ResponseEntity<InsufficientQuantityResponse> handle(InsufficientProductQuantityException exception,HttpServletRequest request){
-        log.error(exception.getMessage(),exception);
+    public ResponseEntity<InsufficientQuantityResponse> handle(InsufficientProductQuantityException exception, HttpServletRequest request) {
+        log.error(exception.getMessage(), exception);
 
         List<ProductVM> products = exception.getProductsWithInsufficientStock()
                 .stream()
-                .map(product -> mapperService.forResponse().map(product,ProductVM.class))
+                .map(product -> mapperService.forResponse().map(product, ProductVM.class))
                 .toList();
 
 
@@ -124,8 +127,8 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler({MethodNotAllowedException.class})
-    public ResponseEntity<DefaultExceptionResponse> handle(MethodArgumentNotValidException exception, HttpServletRequest request){
-        log.error(exception.getMessage(),exception);
+    public ResponseEntity<DefaultExceptionResponse> handle(MethodArgumentNotValidException exception, HttpServletRequest request) {
+        log.error(exception.getMessage(), exception);
         return ResponseEntity.badRequest().body(DefaultExceptionResponse.builder()
                 .status(HttpStatus.BAD_REQUEST.value())
                 .error(HttpStatus.BAD_REQUEST.getReasonPhrase())

--- a/backend/src/main/java/com/ahmetaksunger/ecommerce/exception/InvalidCartException.java
+++ b/backend/src/main/java/com/ahmetaksunger/ecommerce/exception/InvalidCartException.java
@@ -1,0 +1,7 @@
+package com.ahmetaksunger.ecommerce.exception;
+
+public class InvalidCartException extends RuntimeException {
+    public InvalidCartException() {
+        super(ExceptionMessages.INVALID_CART.message());
+    }
+}

--- a/backend/src/main/java/com/ahmetaksunger/ecommerce/model/Cart.java
+++ b/backend/src/main/java/com/ahmetaksunger/ecommerce/model/Cart.java
@@ -1,10 +1,7 @@
 package com.ahmetaksunger.ecommerce.model;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 import java.util.List;
@@ -29,13 +26,7 @@ public class Cart extends BaseEntity {
     private List<CartItem> cartItems;
 
     @Enumerated(EnumType.STRING)
-    private CartStatus status;
+    @Builder.Default
+    private CartStatus status = CartStatus.ACTIVE;
 
-    private void activateCart() {
-        this.status = CartStatus.ACTIVE;
-    }
-
-    private void deactivateCart() {
-        this.status = CartStatus.INACTIVE;
-    }
 }

--- a/backend/src/main/java/com/ahmetaksunger/ecommerce/model/Cart.java
+++ b/backend/src/main/java/com/ahmetaksunger/ecommerce/model/Cart.java
@@ -1,7 +1,10 @@
 package com.ahmetaksunger.ecommerce.model;
 
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 import java.util.List;
@@ -10,9 +13,10 @@ import java.util.List;
 @Table(name = "carts")
 @AllArgsConstructor
 @NoArgsConstructor
-@Getter @Setter
+@Getter
+@Setter
 @SuperBuilder
-public class Cart extends BaseEntity{
+public class Cart extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
@@ -21,6 +25,17 @@ public class Cart extends BaseEntity{
     @ManyToOne
     private Customer customer;
 
-    @OneToMany(mappedBy = "cart",cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy = "cart", cascade = CascadeType.REMOVE)
     private List<CartItem> cartItems;
+
+    @Enumerated(EnumType.STRING)
+    private CartStatus status;
+
+    private void activateCart() {
+        this.status = CartStatus.ACTIVE;
+    }
+
+    private void deactivateCart() {
+        this.status = CartStatus.INACTIVE;
+    }
 }

--- a/backend/src/main/java/com/ahmetaksunger/ecommerce/model/Cart.java
+++ b/backend/src/main/java/com/ahmetaksunger/ecommerce/model/Cart.java
@@ -18,7 +18,7 @@ public class Cart extends BaseEntity{
     @GeneratedValue(strategy = GenerationType.AUTO)
     private long id;
 
-    @OneToOne
+    @ManyToOne
     private Customer customer;
 
     @OneToMany(mappedBy = "cart",cascade = CascadeType.REMOVE)

--- a/backend/src/main/java/com/ahmetaksunger/ecommerce/model/CartStatus.java
+++ b/backend/src/main/java/com/ahmetaksunger/ecommerce/model/CartStatus.java
@@ -1,0 +1,5 @@
+package com.ahmetaksunger.ecommerce.model;
+
+public enum CartStatus {
+    ACTIVE,INACTIVE
+}

--- a/backend/src/main/java/com/ahmetaksunger/ecommerce/model/Customer.java
+++ b/backend/src/main/java/com/ahmetaksunger/ecommerce/model/Customer.java
@@ -19,11 +19,11 @@ public class Customer extends User{
     @Column(name = "phone_number",nullable = false)
     private String phoneNumber;
 
-    @OneToOne(
+    @OneToMany(
             mappedBy = "customer",
             cascade = CascadeType.PERSIST
     )
-    private Cart cart;
+    private List<Cart> carts;
 
     @OneToMany(mappedBy = "customer")
     private List<Order> orders;

--- a/backend/src/main/java/com/ahmetaksunger/ecommerce/model/Order.java
+++ b/backend/src/main/java/com/ahmetaksunger/ecommerce/model/Order.java
@@ -28,7 +28,7 @@ public class Order extends BaseEntity{
     @ManyToOne
     private Address address;
 
-    @ManyToOne
+    @OneToOne
     private Cart cart;
 
     @ManyToOne

--- a/backend/src/main/java/com/ahmetaksunger/ecommerce/repository/CartRepository.java
+++ b/backend/src/main/java/com/ahmetaksunger/ecommerce/repository/CartRepository.java
@@ -12,5 +12,5 @@ public interface CartRepository extends JpaRepository<Cart, Long> {
 
     Optional<Cart> findByCustomerId(long customerId);
 
-    Optional<Cart> findByCartStatus(CartStatus status);
+    Optional<Cart> findByCustomerIdAndStatus(Long customerId,CartStatus status);
 }

--- a/backend/src/main/java/com/ahmetaksunger/ecommerce/repository/CartRepository.java
+++ b/backend/src/main/java/com/ahmetaksunger/ecommerce/repository/CartRepository.java
@@ -3,6 +3,7 @@ package com.ahmetaksunger.ecommerce.repository;
 import com.ahmetaksunger.ecommerce.model.Cart;
 import com.ahmetaksunger.ecommerce.model.CartStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
@@ -12,5 +13,6 @@ public interface CartRepository extends JpaRepository<Cart, Long> {
 
     Optional<Cart> findByCustomerId(long customerId);
 
-    Optional<Cart> findByCustomerIdAndStatus(Long customerId,CartStatus status);
+    @Query("select c from Cart c where c.customer.id = ?1 and c.status='ACTIVE'")
+    Optional<Cart> findActiveCartsByCustomerId(Long customerId);
 }

--- a/backend/src/main/java/com/ahmetaksunger/ecommerce/repository/CartRepository.java
+++ b/backend/src/main/java/com/ahmetaksunger/ecommerce/repository/CartRepository.java
@@ -1,13 +1,16 @@
 package com.ahmetaksunger.ecommerce.repository;
 
 import com.ahmetaksunger.ecommerce.model.Cart;
+import com.ahmetaksunger.ecommerce.model.CartStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface CartRepository extends JpaRepository<Cart,Long> {
+public interface CartRepository extends JpaRepository<Cart, Long> {
 
     Integer countByCustomerId(long customerId);
+
     Optional<Cart> findByCustomerId(long customerId);
 
+    Optional<Cart> findByCartStatus(CartStatus status);
 }

--- a/backend/src/main/java/com/ahmetaksunger/ecommerce/service/AuthenticationImpl.java
+++ b/backend/src/main/java/com/ahmetaksunger/ecommerce/service/AuthenticationImpl.java
@@ -41,7 +41,7 @@ public class AuthenticationImpl implements AuthenticationService {
         var jwt = jwtService.generateToken(user);
         if (user.getUserType().equals(UserType.CUSTOMER)) {
             Customer customer = customerRepository.findById(user.getId()).orElseThrow();
-            Cart activeCart = cartRepository.findByCartStatus(CartStatus.ACTIVE).orElseThrow(CartNotFoundException::new);
+            Cart activeCart = cartRepository.findByCustomerIdAndStatus(customer.getId(), CartStatus.ACTIVE).orElseThrow(CartNotFoundException::new);
             var response = mapperService.forResponse().map(customer, CustomerAuthenticationResponse.class);
             response.setCartId(activeCart.getId());
             response.setJwt(jwt);
@@ -104,11 +104,13 @@ public class AuthenticationImpl implements AuthenticationService {
                 .phoneNumber(registerCustomerRequest.getPhoneNumber())
                 .userType(UserType.CUSTOMER)
                 .build();
+
+        Customer dbCustomer = customerRepository.save(customer);
         Cart cart = Cart.builder()
                 .customer(customer)
                 .build();
         cartRepository.save(cart);
-        var response = mapperService.forResponse().map(customerRepository.save(customer), CustomerAuthenticationResponse.class);
+        var response = mapperService.forResponse().map(dbCustomer, CustomerAuthenticationResponse.class);
         response.setJwt(jwtService.generateToken(customer));
         response.setCartId(cart.getId());
         return response;

--- a/backend/src/main/java/com/ahmetaksunger/ecommerce/service/AuthenticationImpl.java
+++ b/backend/src/main/java/com/ahmetaksunger/ecommerce/service/AuthenticationImpl.java
@@ -12,6 +12,7 @@ import com.ahmetaksunger.ecommerce.model.Cart;
 import com.ahmetaksunger.ecommerce.model.Customer;
 import com.ahmetaksunger.ecommerce.model.Seller;
 import com.ahmetaksunger.ecommerce.model.UserType;
+import com.ahmetaksunger.ecommerce.repository.CartRepository;
 import com.ahmetaksunger.ecommerce.repository.CustomerRepository;
 import com.ahmetaksunger.ecommerce.repository.SellerRepository;
 import com.ahmetaksunger.ecommerce.repository.UserRepository;
@@ -33,6 +34,7 @@ public class AuthenticationImpl implements AuthenticationService {
     private final JwtService jwtService;
     private final AuthenticationManager authenticationManager;
     private final MapperService mapperService;
+    private final CartRepository cartRepository;
 
     @Override
     public AuthenticationResponse authenticate(AuthenticationRequest authenticationRequest) {
@@ -105,7 +107,7 @@ public class AuthenticationImpl implements AuthenticationService {
         Cart cart = Cart.builder()
                 .customer(customer)
                 .build();
-        customer.setCart(cart);
+        cartRepository.save(cart);
         var response = mapperService.forResponse().map(customerRepository.save(customer), CustomerAuthenticationResponse.class);
         response.setJwt(jwtService.generateToken(customer));
         return response;

--- a/backend/src/main/java/com/ahmetaksunger/ecommerce/service/AuthenticationImpl.java
+++ b/backend/src/main/java/com/ahmetaksunger/ecommerce/service/AuthenticationImpl.java
@@ -41,7 +41,7 @@ public class AuthenticationImpl implements AuthenticationService {
         var jwt = jwtService.generateToken(user);
         if (user.getUserType().equals(UserType.CUSTOMER)) {
             Customer customer = customerRepository.findById(user.getId()).orElseThrow();
-            Cart activeCart = cartRepository.findByCustomerIdAndStatus(customer.getId(), CartStatus.ACTIVE).orElseThrow(CartNotFoundException::new);
+            Cart activeCart = cartRepository.findActiveCartsByCustomerId(customer.getId()).orElseThrow(CartNotFoundException::new);
             var response = mapperService.forResponse().map(customer, CustomerAuthenticationResponse.class);
             response.setCartId(activeCart.getId());
             response.setJwt(jwt);

--- a/backend/src/main/java/com/ahmetaksunger/ecommerce/service/CartItemManager.java
+++ b/backend/src/main/java/com/ahmetaksunger/ecommerce/service/CartItemManager.java
@@ -37,6 +37,7 @@ public class CartItemManager implements CartItemService{
         //Rules
         cartRules.verifyCartBelongsToUser(cart,loggedInUser, UnauthorizedException.class);
         cartRules.checkIfQuantityIsValid(quantity,product);
+        cartRules.checkIfCartActive(cart);
 
         CartItem cartItem = CartItem
                 .builder()

--- a/backend/src/main/java/com/ahmetaksunger/ecommerce/service/CartManager.java
+++ b/backend/src/main/java/com/ahmetaksunger/ecommerce/service/CartManager.java
@@ -41,14 +41,9 @@ public class CartManager implements CartService {
     }
 
     @Override
-    public Cart findByCustomerId(long id) {
-        return cartRepository.findByCustomerId(id).orElseThrow(CartNotFoundException::new);
-    }
-
-    @Override
     public CartVM getCartByCustomerId(long customerId, User loggedInUser) {
 
-        Cart cart = cartRepository.findByCustomerId(customerId).orElseThrow(CartNotFoundException::new);
+        Cart cart = cartRepository.findActiveCartsByCustomerId(customerId).orElseThrow(CartNotFoundException::new);
 
         //Rules
         cartRules.verifyCartBelongsToUser(cart, loggedInUser, UnauthorizedException.class);

--- a/backend/src/main/java/com/ahmetaksunger/ecommerce/service/CartManager.java
+++ b/backend/src/main/java/com/ahmetaksunger/ecommerce/service/CartManager.java
@@ -5,6 +5,7 @@ import com.ahmetaksunger.ecommerce.exception.NotAllowedException.UnauthorizedExc
 import com.ahmetaksunger.ecommerce.exception.NotFoundException.CartNotFoundException;
 import com.ahmetaksunger.ecommerce.mapper.MapperService;
 import com.ahmetaksunger.ecommerce.model.Cart;
+import com.ahmetaksunger.ecommerce.model.CartStatus;
 import com.ahmetaksunger.ecommerce.model.Customer;
 import com.ahmetaksunger.ecommerce.model.User;
 import com.ahmetaksunger.ecommerce.repository.CartRepository;
@@ -12,21 +13,16 @@ import com.ahmetaksunger.ecommerce.service.rules.CartRules;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.Date;
-import java.util.List;
-
 @Service
 @RequiredArgsConstructor
-public class CartManager implements CartService{
+public class CartManager implements CartService {
 
     private final CartRepository cartRepository;
     private final CartRules cartRules;
     private final MapperService mapperService;
+
     @Override
     public Cart create(User user) {
-
-        //Rules
-        cartRules.checkIfUserAlreadyHasACart(user);
 
         Cart cart = Cart.builder()
                 .customer((Customer) user)
@@ -39,7 +35,7 @@ public class CartManager implements CartService{
     public void delete(long cartId, User loggedInUser) {
 
         //Rules
-        cartRules.checkIfCanDelete(cartId,loggedInUser);
+        cartRules.checkIfCanDelete(cartId, loggedInUser);
 
         cartRepository.deleteById(cartId);
     }
@@ -50,16 +46,37 @@ public class CartManager implements CartService{
     }
 
     @Override
-    public CartVM getCartByCustomerId(long customerId,User loggedInUser) {
+    public CartVM getCartByCustomerId(long customerId, User loggedInUser) {
 
         Cart cart = cartRepository.findByCustomerId(customerId).orElseThrow(CartNotFoundException::new);
 
         //Rules
-        cartRules.verifyCartBelongsToUser(cart,loggedInUser, UnauthorizedException.class);
+        cartRules.verifyCartBelongsToUser(cart, loggedInUser, UnauthorizedException.class);
 
-        var response = mapperService.forResponse().map(cart,CartVM.class);
+        var response = mapperService.forResponse().map(cart, CartVM.class);
         response.setTotal(PriceCalculator.calculateTotal(cart));
         return response;
+    }
+
+    /**
+     *  Activates the cart by setting the {@link CartStatus} ACTIVE
+     *
+     * @param cart Cart
+     */
+    @Override
+    public void activateCart(Cart cart) {
+        cart.setStatus(CartStatus.ACTIVE);
+        cartRepository.save(cart);
+    }
+
+    /**
+     * Deactivates the cart by setting the {@link CartStatus} INACTIVE
+     * @param cart Cart
+     */
+    @Override
+    public void deactivateCart(Cart cart) {
+        cart.setStatus(CartStatus.INACTIVE);
+        cartRepository.save(cart);
     }
 
 }

--- a/backend/src/main/java/com/ahmetaksunger/ecommerce/service/CartService.java
+++ b/backend/src/main/java/com/ahmetaksunger/ecommerce/service/CartService.java
@@ -2,6 +2,7 @@ package com.ahmetaksunger.ecommerce.service;
 
 import com.ahmetaksunger.ecommerce.dto.response.CartVM;
 import com.ahmetaksunger.ecommerce.model.Cart;
+import com.ahmetaksunger.ecommerce.model.CartStatus;
 import com.ahmetaksunger.ecommerce.model.User;
 
 import java.util.List;
@@ -15,4 +16,8 @@ public interface CartService {
     Cart findByCustomerId(long id);
 
     CartVM getCartByCustomerId(long customerId,User loggedInUser);
+
+    void activateCart(Cart cart);
+
+    void deactivateCart(Cart cart);
 }

--- a/backend/src/main/java/com/ahmetaksunger/ecommerce/service/CartService.java
+++ b/backend/src/main/java/com/ahmetaksunger/ecommerce/service/CartService.java
@@ -13,8 +13,6 @@ public interface CartService {
 
     void delete(long cartId, User loggedInUser);
 
-    Cart findByCustomerId(long id);
-
     CartVM getCartByCustomerId(long customerId,User loggedInUser);
 
     void activateCart(Cart cart);

--- a/backend/src/main/java/com/ahmetaksunger/ecommerce/service/OrderManager.java
+++ b/backend/src/main/java/com/ahmetaksunger/ecommerce/service/OrderManager.java
@@ -10,6 +10,7 @@ import com.ahmetaksunger.ecommerce.mapper.MapperService;
 import com.ahmetaksunger.ecommerce.model.*;
 import com.ahmetaksunger.ecommerce.repository.*;
 import com.ahmetaksunger.ecommerce.service.rules.AddressRules;
+import com.ahmetaksunger.ecommerce.service.rules.CartRules;
 import com.ahmetaksunger.ecommerce.service.rules.OrderRules;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -37,6 +38,7 @@ public class OrderManager implements OrderService {
     private final AddressRules addressRules;
     private final AddressRepository addressRepository;
     private final CartService cartService;
+    private final CartRules cartRules;
 
 
     /**
@@ -75,6 +77,7 @@ public class OrderManager implements OrderService {
         orderRules.checkInsufficientStock(cart); // TODO: Optimistic - Pessimistic lock
         orderRules.checkIfCartIsEmpty(cart);
         addressRules.verifyAddressBelongsToUser(address,customer, UnauthorizedException.class);
+        cartRules.checkIfCartActive(cart);
 
         Order order = Order.builder()
                 .total(PriceCalculator.calculateTotal(cart))

--- a/backend/src/main/java/com/ahmetaksunger/ecommerce/service/OrderManager.java
+++ b/backend/src/main/java/com/ahmetaksunger/ecommerce/service/OrderManager.java
@@ -85,7 +85,9 @@ public class OrderManager implements OrderService {
         // Creating a new cart for the customer
         Cart newCart = cartService.create(customer);
 
-        return mapperService.forResponse().map(dbOrder, OrderCompletedResponse.class);
+        var response = mapperService.forResponse().map(dbOrder, OrderCompletedResponse.class);
+        response.setNewCartId(newCart.getId());
+        return response;
     }
 
     /**

--- a/backend/src/main/java/com/ahmetaksunger/ecommerce/service/OrderManager.java
+++ b/backend/src/main/java/com/ahmetaksunger/ecommerce/service/OrderManager.java
@@ -18,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.math.BigDecimal;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -37,6 +38,28 @@ public class OrderManager implements OrderService {
     private final AddressRepository addressRepository;
     private final CartService cartService;
 
+
+    /**
+     *
+     * <p> - Verifies that the specified cart, payment detail, and address belong to the customer.</p>
+     * <p> - Checks if the products in the cart still have enough stocks</p>
+     * <p> - Checks if the cart is empty</p>
+     *
+     * <p>If all the rules pass:</p>
+     * <p>1-) It creates an order and saves it to the database</p>
+     * <p>2-) It reduces the bought products' quantities by one</p>
+     * <p>3-) It increments the sellers' total revenues</p>
+     * <p>4-) It deactivates the customer's used cart</p>
+     * <p>5-) It creates a new cart for the customer</p>
+     * <p>Then returns {@link OrderCompletedResponse}</p>
+     * @param createOrderRequest {@link CreateOrderRequest}
+     * @param loggedInUser {@link Customer}
+     * @return {@link OrderCompletedResponse}
+     * @see OrderRules
+     * @see AddressRules
+     * @see CartService
+     * @see ProductService#reduceQuantityForBoughtProducts(List)
+     */
     @Override
     @Transactional
     public OrderCompletedResponse create(CreateOrderRequest createOrderRequest, User loggedInUser) {

--- a/backend/src/main/java/com/ahmetaksunger/ecommerce/service/rules/CartRules.java
+++ b/backend/src/main/java/com/ahmetaksunger/ecommerce/service/rules/CartRules.java
@@ -17,6 +17,8 @@ import org.springframework.stereotype.Component;
 public class CartRules {
 
     private final CartRepository cartRepository;
+
+    @Deprecated
     public void checkIfUserAlreadyHasACart(User user){
         if(cartRepository.countByCustomerId(user.getId()) > 0){
             throw new UserAlreadyHasCartException();

--- a/backend/src/main/java/com/ahmetaksunger/ecommerce/service/rules/CartRules.java
+++ b/backend/src/main/java/com/ahmetaksunger/ecommerce/service/rules/CartRules.java
@@ -1,11 +1,13 @@
 package com.ahmetaksunger.ecommerce.service.rules;
 
 import com.ahmetaksunger.ecommerce.exception.InsufficientProductQuantityException;
+import com.ahmetaksunger.ecommerce.exception.InvalidCartException;
 import com.ahmetaksunger.ecommerce.exception.NotAllowedException.CartDeletionNotAllowedException;
 import com.ahmetaksunger.ecommerce.exception.NotAllowedException.UnauthorizedException;
 import com.ahmetaksunger.ecommerce.exception.NotFoundException.CartNotFoundException;
 import com.ahmetaksunger.ecommerce.exception.UserAlreadyHasCartException;
 import com.ahmetaksunger.ecommerce.model.Cart;
+import com.ahmetaksunger.ecommerce.model.CartStatus;
 import com.ahmetaksunger.ecommerce.model.Product;
 import com.ahmetaksunger.ecommerce.model.User;
 import com.ahmetaksunger.ecommerce.repository.CartRepository;
@@ -44,6 +46,12 @@ public class CartRules {
     public void checkIfQuantityIsValid(int quantity, Product product){
         if(quantity > product.getQuantity()){
             throw new InsufficientProductQuantityException(product);
+        }
+    }
+
+    public void checkIfCartActive(Cart cart){
+        if(cart.getStatus().equals(CartStatus.INACTIVE)){
+            throw new InvalidCartException();
         }
     }
 }


### PR DESCRIPTION
Back in the project, we would create one cart for a customer and continue with it. So after an order, we would delete all the cart items from the cart, so that the customer could use the cart again to order.

But now, we are no longer limiting customers to one cart. So after an order, the customer's used cart will be marked as **`INACTIVE`**.  And a new cart will be created for the customer.
With these changes, we can now keep track of the ordered products from the **`orders`** table, by simply looking at the carts used.
